### PR TITLE
Model 6 observer changes

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
@@ -3,4 +3,4 @@ from vivarium_csu_sanofi_multiple_myeloma.components.treatment import (
     MultipleMyelomaTreatmentCoverage,
     MultipleMyelomaTreatmentEffect,
 )
-from vivarium_csu_sanofi_multiple_myeloma.components.observers import MultipleMyelomaTreatmentObserver
+from vivarium_csu_sanofi_multiple_myeloma.components.observers import MortalityObserver, MultipleMyelomaTreatmentObserver

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
@@ -1,4 +1,6 @@
-from vivarium_csu_sanofi_multiple_myeloma.components.multiple_myeloma import MultipleMyeloma
+from vivarium_csu_sanofi_multiple_myeloma.components.multiple_myeloma import (
+    MultipleMyeloma,
+)
 from vivarium_csu_sanofi_multiple_myeloma.components.treatment import (
     MultipleMyelomaTreatmentCoverage,
     MultipleMyelomaTreatmentEffect,
@@ -6,5 +8,6 @@ from vivarium_csu_sanofi_multiple_myeloma.components.treatment import (
 from vivarium_csu_sanofi_multiple_myeloma.components.observers import (
     DiseaseObserver,
     MortalityObserver,
-    MultipleMyelomaTreatmentObserver
+    MultipleMyelomaTreatmentObserver,
+    SurvivalObserver,
 )

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/__init__.py
@@ -3,4 +3,8 @@ from vivarium_csu_sanofi_multiple_myeloma.components.treatment import (
     MultipleMyelomaTreatmentCoverage,
     MultipleMyelomaTreatmentEffect,
 )
-from vivarium_csu_sanofi_multiple_myeloma.components.observers import MortalityObserver, MultipleMyelomaTreatmentObserver
+from vivarium_csu_sanofi_multiple_myeloma.components.observers import (
+    DiseaseObserver,
+    MortalityObserver,
+    MultipleMyelomaTreatmentObserver
+)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
@@ -1,11 +1,13 @@
 import itertools
 from collections import Counter
+
 from typing import Callable, Dict, Iterable, List, Tuple, TYPE_CHECKING
 
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
+
 from vivarium_public_health.metrics import MortalityObserver as MortalityObserver_, DiseaseObserver as DiseaseObserver_
 from vivarium_public_health.metrics.utilities import (get_deaths, get_person_time, get_state_person_time,
                                                       get_transition_count,
@@ -242,6 +244,139 @@ class MultipleMyelomaTreatmentObserver:
         return f'{self.__class__.__name__}()'
 
 
+class SurvivalObserver:
+
+    configuration_defaults = {
+        'metrics': {
+            'observation_start': {
+                'year': 2021,
+                'month': 1,
+                'day': 1,
+            }
+        }
+    }
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: 'Builder') -> None:
+        config = builder.configuration.metrics
+        self.observation_start = pd.Timestamp(**config.observation_start)
+        # Pull directly from config rather than the more flexible
+        # builder.time.step_size(). This component depends on a
+        # constant step size.
+        self.step_size = builder.configuration.time.step_size
+        self.bins = (pd.interval_range(0, 60*28, freq=self.step_size)
+                     .append(pd.Index([pd.Interval(60*28, 1000*28)])))
+
+        self.counts = Counter()
+        count_template = 'alive_at_period_{period_start}_line_{treatment_line}'
+        progression_template = 'progressed_by_period_{period_end}_line_{treatment_line}'
+        death_template = 'died_by_period_{period_end}_line_{treatment_line}'
+        self.sim_end_template = 'sim_end_on_period_{period_end}_line_{treatment_line}'
+        self.templates = [
+            ('alive', count_template),
+            ('progressed', progression_template),
+            ('died', death_template),
+        ]
+
+        self.population_view = builder.population.get_view(
+            [f'{s}_event_time' for s in models.MULTIPLE_MYELOMA_WITH_CONDITION_STATES]
+            + [f'{s}_time_since_entrance' for s in models.MULTIPLE_MYELOMA_WITH_CONDITION_STATES]
+            + [models.MULTIPLE_MYELOMA_MODEL_NAME, 'alive', 'exit_time']
+        )
+
+        builder.event.register_listener('collect_metrics', self.on_collect_metrics)
+        builder.event.register_listener('simulation_end', self.on_simulation_end)
+
+        builder.value.register_value_modifier('metrics', self.metrics)
+
+    def on_collect_metrics(self, event: 'Event') -> None:
+        pop = self.get_denominator_pop(event)
+        states = list(models.MULTIPLE_MYELOMA_WITH_CONDITION_STATES)
+
+        for current_state, next_state in zip(states, states[1:] + [states[-1]]):
+            denominator = self.subset_state_denominator(pop, current_state, next_state, event)
+            alive_at_start = (denominator
+                              .groupby('group')
+                              .multiple_myeloma
+                              .count()
+                              .rename('alive'))
+            died_by_end = (denominator[denominator['exit_time'] == event.time]
+                           .groupby('group')
+                           .multiple_myeloma
+                           .count()
+                           .rename('died'))
+            progressed_by_end = (denominator[denominator[f'{next_state}_event_time'] == event.time]
+                                 .groupby('group')
+                                 .multiple_myeloma
+                                 .count()
+                                 .rename('progressed'))
+            survival_results = pd.concat([alive_at_start, died_by_end, progressed_by_end], axis=1)
+            survival_results.index = survival_results.index.astype(pd.Interval)
+            treatment_line = current_state.split('_')[-1]
+            for interval, interval_data in survival_results.iterrows():
+                for measure, template in self.templates:
+                    key = template.format(
+                        treatment_line=treatment_line,
+                        period_start=interval.left,
+                        period_end=interval.right,
+                    )
+                    self.counts[key] += interval_data.loc[measure]
+
+    def on_simulation_end(self, event: 'Event'):
+        pop = self.get_denominator_pop(event)
+        states = list(models.MULTIPLE_MYELOMA_WITH_CONDITION_STATES)
+
+        for current_state, next_state in zip(states, states[1:] + [states[-1]]):
+            denominator = self.subset_state_denominator(pop, current_state, next_state, event)
+            right_censored_mask = ~(
+                (denominator['exit_time'] != event.time)
+                | (denominator[f'{next_state}_event_time'] == event.time)
+            )
+            right_censored = (denominator[right_censored_mask]
+                              .groupby('group')
+                              .multiple_myeloma
+                              .count()
+                              .rename('right_censored'))
+            treatment_line = current_state.split('_')[-1]
+            for interval, count in right_censored.iteritems():
+                key = self.sim_end_template.format(
+                    treatment_line=treatment_line,
+                    period_end=interval.right,
+                )
+                self.counts[key] += count
+
+    def metrics(self, index: pd.Index, metrics: Dict[str, float]) -> Dict[str, float]:
+        metrics.update(self.counts)
+        return metrics
+
+    def get_denominator_pop(self, event: 'Event'):
+        pop = self.population_view.get(event.index)
+        living = pop['alive'] == 'alive'
+        died_this_step = (pop['alive'] == 'dead') & (pop['exit_time'] == event.time)
+        in_denominator = living | died_this_step
+        return pop.loc[in_denominator]
+
+    def subset_state_denominator(self, pop: pd.DataFrame, current_state: str, next_state: str, event: 'Event'):
+        left_censored = (pop[f'{current_state}_event_time'].notnull()
+                         & (pop[f'{current_state}_event_time'] < self.observation_start))
+        in_current_state_denominator = ~left_censored & (
+            # In the current state and didn't get there this time step
+            ((pop[models.MULTIPLE_MYELOMA_MODEL_NAME] == current_state)
+             & (pop[f'{current_state}_event_time'] < event.time))
+            # or in the next state, but not til the start of the next step.
+            | ((pop[models.MULTIPLE_MYELOMA_MODEL_NAME] == next_state)
+               & (pop[f'{next_state}_event_time'] == event.time))
+        )
+
+        denominator = pop.loc[in_current_state_denominator].copy()
+        denominator['group'] = pd.cut(denominator[f'{current_state}_time_since_entrance'], self.bins)
+        return denominator
+
+                               
 class DiseaseObserver(DiseaseObserver_):
 
     def __init__(self, disease: str, stratify_by_treatment: str = 'True'):

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
@@ -1,13 +1,208 @@
+import itertools
 from collections import Counter
-from typing import Dict, TYPE_CHECKING
+from typing import Callable, Dict, Iterable, List, Tuple, TYPE_CHECKING
 
 import pandas as pd
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
+from vivarium_public_health.metrics import MortalityObserver as MortalityObserver_
+from vivarium_public_health.metrics.utilities import (get_deaths, get_person_time, get_transition_count,
+                                                      get_years_lived_with_disability, get_years_of_life_lost,
+                                                      TransitionString)
 
-from vivarium_csu_sanofi_multiple_myeloma.constants import models
+from vivarium_csu_sanofi_multiple_myeloma.constants import models, results
 
-if TYPE_CHECKING:
-    from vivarium.framework.engine import Builder
-    from vivarium.framework.event import Event
+
+class ResultsStratifier:
+    """Centralized component for handling results stratification.
+
+    This should be used as a sub-component for observers.  The observers
+    can then ask this component for population subgroups and labels during
+    results production and have this component manage adjustments to the
+    final column labels for the subgroups.
+
+    """
+
+    def __init__(self, observer_name: str, stratify_by_treatment: bool = True):
+        self.name = f'{observer_name}_results_stratifier'
+        self.stratify_by_treatment = stratify_by_treatment
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder):
+        """Perform this component's setup."""
+        # The only thing you should request here are resources necessary for results stratification.
+        self.pipelines = {}
+        columns_required = [
+            'age',
+            'multiple_myeloma_treatment',
+            'retreated'
+        ]
+
+        def get_treatment_state_function(state):
+            return lambda: self.population_values['multiple_myeloma_treatment'] == state
+
+        def get_retreatment_state_function(state):
+            return lambda: self.population_values['retreated'] == state
+
+        self.stratification_levels = {}
+
+        if self.stratify_by_treatment:
+            self.stratification_levels['treatment_state'] = {
+                treatment_state: get_treatment_state_function(treatment_state)
+                for treatment_state in models.TREATMENTS
+            }
+            self.stratification_levels['retreated'] = {
+                retreatment_state: get_retreatment_state_function(retreatment_state)
+                for retreatment_state in (True, False)
+            }
+
+        self.population_view = builder.population.get_view(columns_required)
+        self.pipeline_values = {pipeline: None for pipeline in self.pipelines}
+        self.population_values = None
+        self.stratification_groups = None
+
+        builder.population.initializes_simulants(self.on_initialize_simulants,
+                                                 requires_columns=columns_required,
+                                                 requires_values=list(self.pipelines.keys()))
+
+        builder.event.register_listener('time_step__prepare', self.on_timestep_prepare)
+
+    # noinspection PyAttributeOutsideInit
+    def on_initialize_simulants(self, pop_data: SimulantData):
+        self.pipeline_values = {name: pipeline(pop_data.index) for name, pipeline in self.pipelines.items()}
+        self.population_values = self.population_view.get(pop_data.index)
+        self.stratification_groups = self.get_stratification_groups(pop_data.index)
+
+    def get_stratification_groups(self, index):
+        stratification_groups = pd.Series('', index=index)
+        all_stratifications = self.get_all_stratifications()
+        for stratification in all_stratifications:
+            stratification_group_name = '_'.join([f'{metric["metric"]}_{metric["category"]}'
+                                                  for metric in stratification])
+            mask = pd.Series(True, index=index)
+            for metric in stratification:
+                mask &= self.stratification_levels[metric['metric']][metric['category']]()
+            stratification_groups.loc[mask] = stratification_group_name
+        return stratification_groups
+
+    def append_new_entrants(self, existing_data: pd.Series, new_index: pd.Index, getter: Callable):
+        intersection = existing_data.loc[new_index.intersection(existing_data.index)]
+
+        new_entrants_index = new_index.difference(self.stratification_groups.index)
+        new_entrants_stratifications = getter(new_entrants_index)
+        return intersection.append(new_entrants_stratifications)
+
+    # noinspection PyAttributeOutsideInit
+    def on_timestep_prepare(self, event: Event):
+        self.pipeline_values = {name: pipeline(event.index) for name, pipeline in self.pipelines.items()}
+        self.population_values = self.population_view.get(event.index)
+        self.stratification_groups = self.get_stratification_groups(event.index)
+
+    def get_all_stratifications(self) -> List[Tuple[Dict[str, str], ...]]:
+        """
+        Gets all stratification combinations. Returns a List of Stratifications. Each Stratification is represented as a
+        Tuple of Stratification Levels. Each Stratification Level is represented as a Dictionary with keys 'metric' and
+        'category'. 'metric' refers to the stratification level's name, and 'category' refers to the stratification
+        category.
+
+        If no stratification levels are defined, returns a List with a single empty Tuple
+        """
+        # Get list of lists of metric and category pairs for each metric
+        groups = [[{'metric': metric, 'category': category} for category, category_mask in category_maps.items()]
+                  for metric, category_maps in self.stratification_levels.items()]
+        # Get product of all stratification combinations
+        return list(itertools.product(*groups))
+
+    @staticmethod
+    def get_stratification_key(stratification: Iterable[Dict[str, str]]) -> str:
+        return ('' if not stratification
+                else '_'.join([f'{metric["metric"]}_{metric["category"]}' for metric in stratification]))
+
+    def group(self, pop: pd.DataFrame) -> Iterable[Tuple[Tuple[str, ...], pd.DataFrame]]:
+        """Takes the full population and yields stratified subgroups.
+
+        Parameters
+        ----------
+        pop
+            The population to stratify.
+
+        Yields
+        ------
+            A tuple of stratification labels and the population subgroup
+            corresponding to those labels.
+
+        """
+        stratification_groups = self.append_new_entrants(self.stratification_groups, pop.index,
+                                                         self.get_stratification_groups)
+        stratifications = self.get_all_stratifications()
+        for stratification in stratifications:
+            stratification_key = self.get_stratification_key(stratification)
+            if pop.empty:
+                pop_in_group = pop
+            else:
+                pop_in_group = pop.loc[(stratification_groups == stratification_key)]
+            yield (stratification_key,), pop_in_group
+
+    @staticmethod
+    def update_labels(measure_data: Dict[str, float], labels: Tuple[str, ...]) -> Dict[str, float]:
+        """Updates a dict of measure data with stratification labels.
+
+        Parameters
+        ----------
+        measure_data
+            The measure data with unstratified column names.
+        labels
+            The stratification labels. Yielded along with the population
+            subgroup the measure data was produced from by a call to
+            :obj:`ResultsStratifier.group`.
+
+        Returns
+        -------
+            The measure data with column names updated with the stratification
+            labels.
+
+        """
+        stratification_label = f'_{labels[0]}' if labels[0] else ''
+        measure_data = {f'{k}{stratification_label}': v for k, v in measure_data.items()}
+        return measure_data
+
+
+class MortalityObserver(MortalityObserver_):
+
+    def __init__(self, stratify_by_treatment: str = 'True'):
+        super().__init__()
+        self.stratifier = ResultsStratifier(self.name, stratify_by_treatment == 'True')
+
+    @property
+    def sub_components(self) -> List[ResultsStratifier]:
+        return [self.stratifier]
+
+    def metrics(self, index: pd.Index, metrics: Dict[str, float]) -> Dict[str, float]:
+        pop = self.population_view.get(index)
+        pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
+
+        measure_getters = (
+            (get_deaths, (self.causes,)),
+            (get_person_time, ()),
+            (get_years_of_life_lost, (self.life_expectancy, self.causes)),
+        )
+
+        for labels, pop_in_group in self.stratifier.group(pop):
+            base_args = (pop_in_group, self.config.to_dict(), self.start_time, self.clock(), self.age_bins)
+
+            for measure_getter, extra_args in measure_getters:
+                measure_data = measure_getter(*base_args, *extra_args)
+                measure_data = self.stratifier.update_labels(measure_data, labels)
+                metrics.update(measure_data)
+
+        the_living = pop[(pop.alive == 'alive') & pop.tracked]
+        the_dead = pop[pop.alive == 'dead']
+        metrics[results.TOTAL_YLLS_COLUMN] = self.life_expectancy(the_dead.index).sum()
+        metrics['total_population_living'] = len(the_living)
+        metrics['total_population_dead'] = len(the_dead)
+
+        return metrics
 
 
 class MultipleMyelomaTreatmentObserver:

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
@@ -6,8 +6,9 @@ import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium_public_health.metrics import MortalityObserver as MortalityObserver_
-from vivarium_public_health.metrics.utilities import (get_deaths, get_person_time, get_transition_count,
+from vivarium_public_health.metrics import MortalityObserver as MortalityObserver_, DiseaseObserver as DiseaseObserver_
+from vivarium_public_health.metrics.utilities import (get_deaths, get_person_time, get_state_person_time,
+                                                      get_transition_count,
                                                       get_years_lived_with_disability, get_years_of_life_lost,
                                                       TransitionString)
 
@@ -239,3 +240,49 @@ class MultipleMyelomaTreatmentObserver:
 
     def __repr__(self):
         return f'{self.__class__.__name__}()'
+
+
+class DiseaseObserver(DiseaseObserver_):
+
+    def __init__(self, disease: str, stratify_by_treatment: str = 'True'):
+        super().__init__(disease)
+        self.stratifier = ResultsStratifier(self.name, stratify_by_treatment == 'True')
+
+    @property
+    def sub_components(self) -> List[ResultsStratifier]:
+        return [self.stratifier]
+
+    @property
+    def name(self):
+        return f'{self.disease}_disease_observer'
+
+    def on_time_step_prepare(self, event: Event):
+        pop = self.population_view.get(event.index)
+        # Ignoring the edge case where the step spans a new year.
+        # Accrue all counts and time to the current year.
+        for labels, pop_in_group in self.stratifier.group(pop):
+            for state in self.states:
+                # noinspection PyTypeChecker
+                state_person_time_this_step = get_state_person_time(pop_in_group, self.config, self.disease, state,
+                                                                    self.clock().year, event.step_size, self.age_bins)
+                state_person_time_this_step = self.stratifier.update_labels(state_person_time_this_step, labels)
+                self.person_time.update(state_person_time_this_step)
+
+        # This enables tracking of transitions between states
+        prior_state_pop = self.population_view.get(event.index)
+        prior_state_pop[self.previous_state_column] = prior_state_pop[self.disease]
+        self.population_view.update(prior_state_pop)
+
+    def on_collect_metrics(self, event: Event):
+        pop = self.population_view.get(event.index)
+        for labels, pop_in_group in self.stratifier.group(pop):
+            for transition in self.transitions:
+                transition = TransitionString(transition)
+                # noinspection PyTypeChecker
+                transition_counts_this_step = get_transition_count(pop_in_group, self.config, self.disease, transition,
+                                                                   event.time, self.age_bins)
+                transition_counts_this_step = self.stratifier.update_labels(transition_counts_this_step, labels)
+                self.counts.update(transition_counts_this_step)
+
+    def __repr__(self) -> str:
+        return f"DiseaseObserver({self.disease})"

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
@@ -57,7 +57,7 @@ def make_progression_hazard_ratio():
     index_cols = [models.MULTIPLE_MYELOMA_MODEL_NAME, 'multiple_myeloma_treatment', 'retreated']
     hazard_ratio = pd.DataFrame(columns=index_cols + ['hazard_ratio']).set_index(index_cols)
 
-    hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.no_treatment, False)] = 1.0
+    hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
     hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = first_line_isa
@@ -77,6 +77,7 @@ def make_progression_hazard_ratio():
     hazard_ratio['year_start'] = 1990
     hazard_ratio['year_end'] = 2100
     return hazard_ratio
+
 
 def make_mortality_hazard_ratio():
     # TODO: Get a distribution from researchers and sample.
@@ -84,8 +85,8 @@ def make_mortality_hazard_ratio():
     first_line_dara = 0.760  # lower = 0.645, upper = 0.895
     first_line_residual = 1.0024  # lower = 1.0011, upper = 1.0036
 
-    later_line_isa = 1.159  # lower = 1.044, upper = 1.185
-    later_line_isa_retreat = 1.318  # lower = 1.088, upper = 1.370
+    later_line_isa = 1.116  # lower = 1.044, upper = 1.185
+    later_line_isa_retreat = 1.232  # lower = 1.088, upper = 1.370
     later_line_dara = 0.572  # lower = 0.551, upper = 0.594
     later_line_dara_retreat = 0.786  # lower = 0.776, upper = 0.797
     later_line_residual = 1.181  # lower = 1.171, upper = 1.190
@@ -93,7 +94,7 @@ def make_mortality_hazard_ratio():
     index_cols = [models.MULTIPLE_MYELOMA_MODEL_NAME, 'multiple_myeloma_treatment', 'retreated']
     hazard_ratio = pd.DataFrame(columns=index_cols + ['hazard_ratio']).set_index(index_cols)
 
-    hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.no_treatment, False)] = 1.0
+    hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
     hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = first_line_isa
@@ -101,10 +102,10 @@ def make_mortality_hazard_ratio():
     hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = first_line_residual
 
     for line in TREATMENT_LINES.tolist()[1:]:
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = later_line_isa
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = later_line_isa_retreat
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = later_line_dara
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = later_line_dara_retreat
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = later_line_isa
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = later_line_isa_retreat
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = later_line_dara
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = later_line_dara_retreat
         hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = later_line_residual
         hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = later_line_residual
 
@@ -115,6 +116,7 @@ def make_mortality_hazard_ratio():
     return hazard_ratio
 
 
+# TODO XXX: move to data values constants file if more cases
 PROBABILITY_RETREAT = 0.15
 
 
@@ -166,7 +168,7 @@ class MultipleMyelomaTreatmentCoverage:
         current_coverage = self.get_current_coverage(pop_data.creation_time)
         initial_mm_state = self.population_view.subview([models.MULTIPLE_MYELOMA_MODEL_NAME]).get(pop_data.index)
         pop_update = pd.DataFrame({
-            self.treatment_column: models.TREATMENTS.no_treatment,
+            self.treatment_column: models.TREATMENTS.not_treated,
             self.retreatment_eligible_column: 'unknown',
             self.retreated_column: False
         }, index=pop_data.index)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
@@ -4,6 +4,9 @@ import pandas as pd
 
 from vivarium_csu_sanofi_multiple_myeloma.constants import models
 from vivarium_csu_sanofi_multiple_myeloma.constants.metadata import SCENARIOS
+from vivarium_csu_sanofi_multiple_myeloma.constants.data_values import (PROGRESSION_HAZARD_RATE,
+                                                                        MORTALITY_HAZARD_RATE,
+                                                                        PROBABILITY_RETREAT)
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
@@ -42,35 +45,24 @@ def make_treatment_coverage(year, scenario):
     return coverage
 
 
-def make_progression_hazard_ratio():
-    # TODO: Get a distribution from researchers and sample.
-    first_line_isa = 0.429  # lower = 0.368, upper = 0.495
-    first_line_dara = 0.429  # lower = 0.368, upper = 0.495
-    first_line_residual = 1.00581  # lower = 1.0051, upper = 1.0064
-
-    later_line_isa = 0.530  # lower = 0.356, upper = 0.803
-    later_line_isa_retreat = 0.765  # lower = 0.678, upper = 0.902
-    later_line_dara = 0.217  # lower = 0.203, upper = 0.231
-    later_line_dara_retreat = 0.609  # lower = 0.601, upper = 0.616
-    later_line_residual = 1.331  # lower = 1.324, upper = 1.337
-
+def make_progression_hazard_ratio(draw: int):
     index_cols = [models.MULTIPLE_MYELOMA_MODEL_NAME, 'multiple_myeloma_treatment', 'retreated']
     hazard_ratio = pd.DataFrame(columns=index_cols + ['hazard_ratio']).set_index(index_cols)
 
     hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
-    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = first_line_isa
-    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = first_line_dara
-    hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = first_line_residual
+    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_RESIDUAL.get_random_variable(draw)
 
     for line in TREATMENT_LINES.tolist()[1:]:
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = later_line_isa
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = later_line_isa_retreat
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = later_line_dara
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = later_line_dara_retreat
-        hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = later_line_residual
-        hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = later_line_residual
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
 
     hazard_ratio = hazard_ratio.reset_index()
     # FIXME: Super-duper hack to make lookup table work.  Need at least one continuous parameter.
@@ -79,45 +71,30 @@ def make_progression_hazard_ratio():
     return hazard_ratio
 
 
-def make_mortality_hazard_ratio():
-    # TODO: Get a distribution from researchers and sample.
-    first_line_isa = 0.760  # lower = 0.645, upper = 0.895
-    first_line_dara = 0.760  # lower = 0.645, upper = 0.895
-    first_line_residual = 1.0024  # lower = 1.0011, upper = 1.0036
-
-    later_line_isa = 1.116  # lower = 1.044, upper = 1.185
-    later_line_isa_retreat = 1.232  # lower = 1.088, upper = 1.370
-    later_line_dara = 0.572  # lower = 0.551, upper = 0.594
-    later_line_dara_retreat = 0.786  # lower = 0.776, upper = 0.797
-    later_line_residual = 1.181  # lower = 1.171, upper = 1.190
-
+def make_mortality_hazard_ratio(draw: int):
     index_cols = [models.MULTIPLE_MYELOMA_MODEL_NAME, 'multiple_myeloma_treatment', 'retreated']
     hazard_ratio = pd.DataFrame(columns=index_cols + ['hazard_ratio']).set_index(index_cols)
 
     hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
-    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = first_line_isa
-    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = first_line_dara
-    hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = first_line_residual
+    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_RESIDUAL.get_random_variable(draw)
 
     for line in TREATMENT_LINES.tolist()[1:]:
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = later_line_isa
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = later_line_isa_retreat
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = later_line_dara
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = later_line_dara_retreat
-        hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = later_line_residual
-        hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = later_line_residual
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
 
     hazard_ratio = hazard_ratio.reset_index()
     # FIXME: Super-duper hack to make lookup table work.  Need at least one continuous parameter.
     hazard_ratio['year_start'] = 1990
     hazard_ratio['year_end'] = 2100
     return hazard_ratio
-
-
-# TODO XXX: move to data values constants file if more cases
-PROBABILITY_RETREAT = 0.15
 
 
 class MultipleMyelomaTreatmentCoverage:
@@ -293,14 +270,15 @@ class MultipleMyelomaTreatmentEffect:
         return self.__class__.__name__
 
     def setup(self, builder: 'Builder') -> None:
+        draw = builder.configuration.input_data.input_draw_number
         required_columns = [models.MULTIPLE_MYELOMA_MODEL_NAME, 'multiple_myeloma_treatment', 'retreated']
-        progression_hazard_ratio = make_progression_hazard_ratio()
+        progression_hazard_ratio = make_progression_hazard_ratio(draw)
         self.progression_hazard_ratio = builder.lookup.build_table(
             progression_hazard_ratio,
             key_columns=required_columns,
             parameter_columns=['year']
         )
-        mortality_hazard_ratio = make_mortality_hazard_ratio()
+        mortality_hazard_ratio = make_mortality_hazard_ratio(draw)
         self.mortality_hazard_ratio = builder.lookup.build_table(
             mortality_hazard_ratio,
             key_columns=required_columns,
@@ -326,3 +304,4 @@ class MultipleMyelomaTreatmentEffect:
 
     def scale_progression_hazard(self, index: pd.Index, progression_hazard: pd.Series):
         return progression_hazard * self.progression_hazard_ratio(index)
+

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
@@ -1,0 +1,54 @@
+from typing import NamedTuple
+
+from vivarium_csu_sanofi_multiple_myeloma.utilities import LogNormalHazardRate
+
+
+# Progression hazard ratios
+class __ProgressionHazardRate(NamedTuple):
+    FIRST_LINE_ISA: LogNormalHazardRate = LogNormalHazardRate("first_line_isa", 0.429, 0.495) # lower = 0.368, upper = 0.495
+    FIRST_LINE_DARA: LogNormalHazardRate = LogNormalHazardRate("first_line_dara", 0.429, 0.495) # lower = 0.368, upper = 0.495
+    FIRST_LINE_RESIDUAL: LogNormalHazardRate = LogNormalHazardRate("first_line_residual", 1.00581, 1.0064)  # lower = 1.0051, upper = 1.0064
+
+    LATER_LINE_ISA: LogNormalHazardRate = LogNormalHazardRate("later_line_isa", 0.530,  0.803)  # lower = 0.356, upper = 0.803
+    LATER_LINE_ISA_RETREAT: LogNormalHazardRate = LogNormalHazardRate("later_line_isa_retreat", 0.765, 0.902)  # lower = 0.678, upper = 0.902
+    LATER_LINE_DARA: LogNormalHazardRate = LogNormalHazardRate("later_line_dara", 0.217, 0.231)  # lower = 0.203, upper = 0.231
+    LATER_LINE_DARA_RETREAT: LogNormalHazardRate = LogNormalHazardRate("later_line_dara_retreat", 0.609, 0.616) # lower = 0.601, upper = 0.616
+    LATER_LINE_RESIDUAL: LogNormalHazardRate = LogNormalHazardRate("later_line_residual", 1.331, 1.337) # lower = 1.324, upper = 1.337
+
+    @property
+    def name(self):
+        return 'progression_hazard_rate'
+
+    @property
+    def log_name(self):
+        return 'progression hazard rate'
+
+
+PROGRESSION_HAZARD_RATE = __ProgressionHazardRate()
+
+
+# Mortality hazard ratios
+class __MortalityHazardRate(NamedTuple):
+
+    FIRST_LINE_ISA: LogNormalHazardRate = LogNormalHazardRate("first_line_isa", 0.760, 0.895)  # LOWER = 0.645, UPPER = 0.895
+    FIRST_LINE_DARA: LogNormalHazardRate = LogNormalHazardRate("first_line_dara", 0.760, 0.895)  # LOWER = 0.645, UPPER = 0.895
+    FIRST_LINE_RESIDUAL: LogNormalHazardRate = LogNormalHazardRate("first_line_residual", 1.0024, 1.0036)  # LOWER = 1.0011, UPPER = 1.0036
+
+    LATER_LINE_ISA: LogNormalHazardRate = LogNormalHazardRate("later_line_isa", 1.116, 1.185)  # LOWER = 1.044, UPPER = 1.185
+    LATER_LINE_ISA_RETREAT: LogNormalHazardRate = LogNormalHazardRate("later_line_isa_retreat", 1.232, 1.370)  # LOWER = 1.088, UPPER = 1.370
+    LATER_LINE_DARA: LogNormalHazardRate = LogNormalHazardRate("later_line_dara", 0.572, 0.594) # LOWER = 0.551, UPPER = 0.594
+    LATER_LINE_DARA_RETREAT: LogNormalHazardRate = LogNormalHazardRate("later_line_dara_retreat", 0.786, 0.797) # LOWER = 0.776, UPPER = 0.797
+    LATER_LINE_RESIDUAL: LogNormalHazardRate = LogNormalHazardRate("later_line_residual", 1.181, 1.190)  # LOWER = 1.171, UPPER = 1.190
+
+    @property
+    def name(self):
+        return 'mortality_hazard_rate'
+
+    @property
+    def log_name(self):
+        return 'mortality hazard rate'
+
+
+MORTALITY_HAZARD_RATE = __MortalityHazardRate()
+
+PROBABILITY_RETREAT = 0.15

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/models.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/models.py
@@ -52,8 +52,9 @@ STATE_MACHINE_MAP = {
 STATES = tuple(state for model in STATE_MACHINE_MAP.values() for state in model['states'])
 TRANSITIONS = tuple(state for model in STATE_MACHINE_MAP.values() for state in model['transitions'])
 
+
 class __Treatments(NamedTuple):
-    no_treatment: str
+    not_treated: str
     isatuxamib: str
     daratumamab: str
     residual: str

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -24,9 +24,9 @@ STANDARD_COLUMNS = {
 THROWAWAY_COLUMNS = [f'{state}_event_count' for state in models.STATES]
 
 TOTAL_POPULATION_COLUMN_TEMPLATE = 'total_population_{POP_STATE}'
-PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
-DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
-YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
+PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
+DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
+YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
 STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
 TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
@@ -48,7 +48,7 @@ NON_COUNT_TEMPLATES = [
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-YEARS = tuple(range(2021, 2027))
+YEARS = tuple(range(2021, 2026))
 AGE_GROUPS = (
     '15_to_19',
     '20_to_24',
@@ -96,7 +96,8 @@ TEMPLATE_FIELD_MAP = {
     'STATE': models.STATES,
     'TRANSITION': models.TRANSITIONS,
     'TREATMENT': models.TREATMENTS,
-    'TREATMENT_LINE': list(range(5)),
+    'TREATMENT_LINE': list(range(1, 6)),
+    'BOOL': ('True', 'False')
 }
 
 

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -31,6 +31,8 @@ YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_
 STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 TREATMENT_COUNT_COLUMN_TEMPLATE = 'line_{TREATMENT_LINE}_treatment_{TREATMENT}_year_{YEAR}'
+SURVIVAL_ALIVE_TEMPLATE = 'alive_at_period_{LEFT_PERIOD}_line_{TREATMENT_LINE}'
+SURVIVAL_OTHER_TEMPLATE = '{SURVIVAL_METRIC}_period_{RIGHT_PERIOD}_line_{TREATMENT_LINE}'
 
 COLUMN_TEMPLATES = {
     'population': TOTAL_POPULATION_COLUMN_TEMPLATE,
@@ -41,6 +43,8 @@ COLUMN_TEMPLATES = {
     'state_person_time': STATE_PERSON_TIME_COLUMN_TEMPLATE,
     'transition_count': TRANSITION_COUNT_COLUMN_TEMPLATE,
     'treatment_count': TREATMENT_COUNT_COLUMN_TEMPLATE,
+    'survival_alive': SURVIVAL_ALIVE_TEMPLATE,
+    'survival_other': SURVIVAL_OTHER_TEMPLATE,
 }
 
 NON_COUNT_TEMPLATES = [
@@ -86,6 +90,10 @@ CAUSES_OF_DISABILITY = (
     models.MULTIPLE_MYELOMA_5_STATE_NAME,
 )
 
+# CAUTION: This needs to change with the time step size.
+ALL_PERIODS = [i * 28 for i in range(61)] + [28*1000]
+
+
 TEMPLATE_FIELD_MAP = {
     'POP_STATE': POP_STATES,
     'YEAR': YEARS,
@@ -97,7 +105,11 @@ TEMPLATE_FIELD_MAP = {
     'TRANSITION': models.TRANSITIONS,
     'TREATMENT': models.TREATMENTS,
     'TREATMENT_LINE': list(range(1, 6)),
-    'BOOL': ('True', 'False')
+    'BOOL': ('True', 'False'),
+    'SURVIVAL_METRIC': ('progressed_by', 'died_by', 'sim_end_on'),
+    # CAUTION: This needs to change with the time step size.
+    'LEFT_PERIOD': ALL_PERIODS[:-1],
+    'RIGHT_PERIOD': ALL_PERIODS[1:],
 }
 
 

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -28,8 +28,8 @@ PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{A
 DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
-STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
-TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
+STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
+TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}'
 TREATMENT_COUNT_COLUMN_TEMPLATE = 'line_{TREATMENT_LINE}_treatment_{TREATMENT}_year_{YEAR}'
 
 COLUMN_TEMPLATES = {

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
@@ -5,10 +5,10 @@ components:
             - Mortality()
         metrics:
             - DisabilityObserver()
-            - DiseaseObserver('multiple_myeloma')
 
     # Causes an error if left empty. Uncomment when you have components. 
     vivarium_csu_sanofi_multiple_myeloma.components:
+        - DiseaseObserver('multiple_myeloma', 'True')
         - MortalityObserver('True')
         - MultipleMyeloma()
         - MultipleMyelomaTreatmentCoverage()

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
@@ -14,6 +14,7 @@ components:
         - MultipleMyelomaTreatmentCoverage()
         - MultipleMyelomaTreatmentEffect()
         - MultipleMyelomaTreatmentObserver()
+        - SurvivalObserver()
 
 configuration:
     input_data:
@@ -43,6 +44,10 @@ configuration:
         age_end: 95
 
     metrics:
+        observation_start:
+            year: 2021
+            month: 1
+            day: 1
         disability:
             by_age: True
             by_sex: True

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
@@ -5,11 +5,11 @@ components:
             - Mortality()
         metrics:
             - DisabilityObserver()
-            - MortalityObserver()
             - DiseaseObserver('multiple_myeloma')
 
     # Causes an error if left empty. Uncomment when you have components. 
     vivarium_csu_sanofi_multiple_myeloma.components:
+        - MortalityObserver('True')
         - MultipleMyeloma()
         - MultipleMyelomaTreatmentCoverage()
         - MultipleMyelomaTreatmentEffect()
@@ -33,10 +33,10 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2023
+            year: 2025
             month: 12
             day: 31
-        step_size: 180 # Days
+        step_size: 28 # Days
     population:
         population_size: 100000
         age_start: 15

--- a/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
@@ -26,10 +26,10 @@ OUTPUT_COLUMN_SORT_ORDER = [
 def make_measure_data(data):
     measure_data = MeasureData(
         population=get_population_data(data),
-        person_time=get_measure_data(data, 'person_time'),
-        ylls=get_by_cause_measure_data(data, 'ylls'),
+        person_time=get_measure_data(data, 'person_time', stratified_by_treatment=True),
+        ylls=get_by_cause_measure_data(data, 'ylls', stratified_by_treatment=True),
         ylds=get_by_cause_measure_data(data, 'ylds'),
-        deaths=get_by_cause_measure_data(data, 'deaths'),
+        deaths=get_by_cause_measure_data(data, 'deaths', stratified_by_treatment=True),
         state_person_time=get_state_person_time_measure_data(data, 'state_person_time'),
         transition_count=get_transition_count_measure_data(data, 'transition_count'),
         treatment_count=get_treatment_count_measure_data(data, 'treatment_count'),
@@ -120,10 +120,12 @@ def sort_data(data):
     return data.reset_index(drop=True)
 
 
-def split_processing_column(data):
-    # TODO the required splitting here is dependant on what types of stratification exist in the model
+def split_processing_column(data, stratified_by_treatment = False):
     # TODO find a better way to do this:
     #       FutureWarning: Columnar iteration over characters will be deprecated in future releases.
+    if stratified_by_treatment:
+        data['process'], data['retreated'] = data.process.str.split('_retreated_').str
+        data['process'], data['treatment'] = data.process.str.split('_treatment_state_').str
     data['process'], data['age'] = data.process.str.split('_in_age_group_').str
     data['process'], data['sex'] = data.process.str.split('_among_').str
     data['year'] = data.process.str.split('_in_').str[-1]
@@ -139,14 +141,14 @@ def get_population_data(data):
     return sort_data(total_pop)
 
 
-def get_measure_data(data, measure):
+def get_measure_data(data, measure, stratified_by_treatment = False):
     data = pivot_data(data[results.RESULT_COLUMNS(measure) + GROUPBY_COLUMNS])
-    data = split_processing_column(data)
+    data = split_processing_column(data, stratified_by_treatment)
     return sort_data(data)
 
 
-def get_by_cause_measure_data(data, measure):
-    data = get_measure_data(data, measure)
+def get_by_cause_measure_data(data, measure, stratified_by_treatment = False):
+    data = get_measure_data(data, measure, stratified_by_treatment)
     data['measure'], data['cause'] = data.measure.str.split('_due_to_').str
     return sort_data(data)
 
@@ -163,9 +165,10 @@ def get_transition_count_measure_data(data, measure):
     data = get_measure_data(data, measure)
     return sort_data(data)
 
+
 def get_treatment_count_measure_data(data, measure):
     data = pivot_data(data[results.RESULT_COLUMNS(measure) + GROUPBY_COLUMNS])
-    data['treatment_line'], data['process'] = data.process.str.split('_treatment_').str
     data['treatment'], data['year'] = data.process.str.split('_year_').str
+    data['treatment_line'], data['process'] = data.process.str.split('_treatment_').str
     data = data.drop(columns='process')
     return sort_data(data)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
@@ -30,8 +30,8 @@ def make_measure_data(data):
         ylls=get_by_cause_measure_data(data, 'ylls', stratified_by_treatment=True),
         ylds=get_by_cause_measure_data(data, 'ylds'),
         deaths=get_by_cause_measure_data(data, 'deaths', stratified_by_treatment=True),
-        state_person_time=get_state_person_time_measure_data(data, 'state_person_time'),
-        transition_count=get_transition_count_measure_data(data, 'transition_count'),
+        state_person_time=get_state_person_time_measure_data(data, 'state_person_time', stratified_by_treatment=True),
+        transition_count=get_transition_count_measure_data(data, 'transition_count', stratified_by_treatment=True),
         treatment_count=get_treatment_count_measure_data(data, 'treatment_count'),
         survival=get_survival_measure_data(data),
     )
@@ -143,28 +143,28 @@ def get_population_data(data):
     return sort_data(total_pop)
 
 
-def get_measure_data(data, measure, stratified_by_treatment = False):
+def get_measure_data(data, measure, stratified_by_treatment=False):
     data = pivot_data(data[results.RESULT_COLUMNS(measure) + GROUPBY_COLUMNS])
     data = split_processing_column(data, stratified_by_treatment)
     return sort_data(data)
 
 
-def get_by_cause_measure_data(data, measure, stratified_by_treatment = False):
+def get_by_cause_measure_data(data, measure, stratified_by_treatment=False):
     data = get_measure_data(data, measure, stratified_by_treatment)
     data['measure'], data['cause'] = data.measure.str.split('_due_to_').str
     return sort_data(data)
 
 
-def get_state_person_time_measure_data(data, measure):
-    data = get_measure_data(data, measure)
+def get_state_person_time_measure_data(data, measure, stratified_by_treatment):
+    data = get_measure_data(data, measure, stratified_by_treatment)
     data['measure'], data['cause'] = 'state_person_time', data.measure.str.split('_person_time').str[0]
     return sort_data(data)
 
 
-def get_transition_count_measure_data(data, measure):
+def get_transition_count_measure_data(data, measure, stratified_by_treatment):
     # Oops, edge case.
     data = data.drop(columns=[c for c in data.columns if 'event_count' in c and '2041' in c])
-    data = get_measure_data(data, measure)
+    data = get_measure_data(data, measure, stratified_by_treatment)
     return sort_data(data)
 
 

--- a/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
@@ -33,6 +33,7 @@ def make_measure_data(data):
         state_person_time=get_state_person_time_measure_data(data, 'state_person_time'),
         transition_count=get_transition_count_measure_data(data, 'transition_count'),
         treatment_count=get_treatment_count_measure_data(data, 'treatment_count'),
+        survival=get_survival_measure_data(data),
     )
     return measure_data
 
@@ -46,6 +47,7 @@ class MeasureData(NamedTuple):
     state_person_time: pd.DataFrame
     transition_count: pd.DataFrame
     treatment_count: pd.DataFrame
+    survival: pd.DataFrame
 
     def dump(self, output_dir: Path):
         for key, df in self._asdict().items():
@@ -170,5 +172,14 @@ def get_treatment_count_measure_data(data, measure):
     data = pivot_data(data[results.RESULT_COLUMNS(measure) + GROUPBY_COLUMNS])
     data['treatment'], data['year'] = data.process.str.split('_year_').str
     data['treatment_line'], data['process'] = data.process.str.split('_treatment_').str
+    data = data.drop(columns='process')
+    return sort_data(data)
+
+
+def get_survival_measure_data(data):
+    data = pivot_data(data[results.RESULT_COLUMNS('survival_alive') + results.RESULT_COLUMNS('survival_other') + GROUPBY_COLUMNS])
+    data['measure'], data['process'] = data.process.str.split('_period_').str
+    data['period'], data['treatment_line'] = data.process.str.split('_line_').str
+
     data = data.drop(columns='process')
     return sort_data(data)


### PR DESCRIPTION
This change implements observer subclasses for stratifying deaths, person time, state person time, and transition count by treatment (specifically treatment (not treated, isa, dara, residual) + retreated status (True or False) ).  This also implements random sampling of distributions for hazard rates, and includes the survival observer from @collijk.

Tested with a full parallel run and make results.