### PR TITLE
MIC-2524: Update mortality approach per model

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
@@ -109,8 +109,8 @@ class DiseaseStateHazard(DiseaseState):
 
 
 class SusceptibleStateWithEMR(SusceptibleState):
-    def __init__(self, get_data_functions=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, cause, get_data_functions=None, *args, **kwargs):
+        super().__init__(cause, *args, **kwargs)
         self._get_data_functions = get_data_functions if get_data_functions is not None else {}
 
     def add_transition(self, output, source_data_type=None, get_data_functions=None, **kwargs):
@@ -200,9 +200,7 @@ def MultipleMyeloma():
     susceptible = SusceptibleStateWithEMR(
         models.MULTIPLE_MYELOMA_MODEL_NAME,
         get_data_functions={
-            'excess_mortality_rate': lambda *_, builder: (
-                builder.data.load(data_keys.POPULATION.ACMR)  # EMR_s = ACMR - CSMR
-                - builder.data.load(data_keys.MULTIPLE_MYELOMA.GBD_CSMR)),
+            'excess_mortality_rate': lambda _, builder: builder.data.load(data_keys.MULTIPLE_MYELOMA.SUSCEPTIBLE_EMR),
         }
     )
     susceptible.allow_self_transitions()

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
@@ -109,7 +109,14 @@ class DiseaseStateHazard(DiseaseState):
 
 
 def MultipleMyeloma():
-    susceptible = SusceptibleState(models.MULTIPLE_MYELOMA_MODEL_NAME)
+    susceptible = SusceptibleState(
+        models.MULTIPLE_MYELOMA_MODEL_NAME,
+        get_data_functions={
+            'excess_mortality_rate': lambda *_, builder: (
+                builder.data.load(data_keys.MULTIPLE_MYELOMA.CSMR)  # EMR_s = ACMR - CSMR
+                - builder.data.load(data_keys.MULTIPLE_MYELOMA.GBD_CSMR)),
+        }
+    )
     susceptible.allow_self_transitions()
 
     mm_1 = DiseaseStateHazard(models.MULTIPLE_MYELOMA_1_STATE_NAME)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
@@ -108,8 +108,96 @@ class DiseaseStateHazard(DiseaseState):
             return super().add_transition(output, source_data_type, get_data_functions, **kwargs)
 
 
+class SusceptibleStateWithEMR(SusceptibleState):
+    def __init__(self, get_data_functions=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._get_data_functions = get_data_functions if get_data_functions is not None else {}
+
+    def add_transition(self, output, source_data_type=None, get_data_functions=None, **kwargs):
+        if source_data_type == 'rate':
+            if get_data_functions is None:
+                get_data_functions = {
+                    'incidence_rate':
+                        lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.incidence_rate")
+                }
+            elif 'incidence_rate' not in get_data_functions:
+                raise ValueError('You must supply an incidence rate function.')
+        elif source_data_type == 'proportion':
+            if 'proportion' not in get_data_functions:
+                raise ValueError('You must supply a proportion function.')
+
+        return super().add_transition(output, source_data_type, get_data_functions, **kwargs)
+
+    def with_condition(self, index):
+        pop = self.population_view.subview(['alive', self._model]).get(index)
+        with_condition = pop.loc[(pop[self._model] == self.state_id) & (pop['alive'] == 'alive')].index
+        return with_condition
+
+    def load_excess_mortality_rate_data(self, builder):
+        only_morbid = builder.data.load(f'cause.{self._model}.restrictions')['yld_only']
+        if 'excess_mortality_rate' in self._get_data_functions:
+            return self._get_data_functions['excess_mortality_rate'](self.cause, builder)
+        elif only_morbid:
+            return 0
+        else:
+            return builder.data.load(f'{self.cause_type}.{self.cause}.excess_mortality_rate')
+
+    def compute_excess_mortality_rate(self, index):
+        excess_mortality_rate = pd.Series(0, index=index)
+        with_condition = self.with_condition(index)
+        base_excess_mort = self.base_excess_mortality_rate(with_condition)
+        joint_mediated_paf = self.joint_paf(with_condition)
+        excess_mortality_rate.loc[with_condition] = base_excess_mort * (1 - joint_mediated_paf.values)
+        return excess_mortality_rate
+
+    def adjust_mortality_rate(self, index, rates_df):
+        """Modifies the baseline mortality rate for a simulant if they are in this state.
+
+        Parameters
+        ----------
+        index
+            An iterable of integer labels for the simulants.
+        rates_df : `pandas.DataFrame`
+
+        """
+        rate = self.excess_mortality_rate(index, skip_post_processor=True)
+        rates_df[self.state_id] = rate
+        return rates_df
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder):
+        """Performs this component's simulation setup.
+
+        Parameters
+        ----------
+        builder : `engine.Builder`
+            Interface to several simulation tools.
+        """
+        super().setup(builder)
+        excess_mortality_data = self.load_excess_mortality_rate_data(builder)
+        self.base_excess_mortality_rate = builder.lookup.build_table(excess_mortality_data, key_columns=['sex'],
+                                                                     parameter_columns=['age', 'year'])
+        self.excess_mortality_rate = builder.value.register_rate_producer(
+            f'{self.state_id}.excess_mortality_rate',
+            source=self.compute_excess_mortality_rate,
+            requires_columns=['age', 'sex', 'alive', self._model],
+            requires_values=[f'{self.state_id}.excess_mortality_rate.population_attributable_fraction']
+        )
+        paf = builder.lookup.build_table(0)
+        self.joint_paf = builder.value.register_value_producer(
+            f'{self.state_id}.excess_mortality_rate.population_attributable_fraction',
+            source=lambda idx: [paf(idx)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=union_post_processor
+        )
+        builder.value.register_value_modifier('mortality_rate',
+                                              modifier=self.adjust_mortality_rate,
+                                              requires_values=[f'{self.state_id}.excess_mortality_rate'])
+
+
 def MultipleMyeloma():
-    susceptible = SusceptibleState(
+    # TODO: change to disease state, call it susceptible
+    susceptible = SusceptibleStateWithEMR(
         models.MULTIPLE_MYELOMA_MODEL_NAME,
         get_data_functions={
             'excess_mortality_rate': lambda *_, builder: (
@@ -142,7 +230,7 @@ def MultipleMyeloma():
         )
         states.append(rr_mm_state)
 
-    return DiseaseModel(models.MULTIPLE_MYELOMA_MODEL_NAME, states=states)
+    return DiseaseModel(models.MULTIPLE_MYELOMA_MODEL_NAME, states=states, initial_state=susceptible)
 
 
 def load_hazard_rate(builder: 'Builder', state_id, measure):

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/multiple_myeloma.py
@@ -113,7 +113,7 @@ def MultipleMyeloma():
         models.MULTIPLE_MYELOMA_MODEL_NAME,
         get_data_functions={
             'excess_mortality_rate': lambda *_, builder: (
-                builder.data.load(data_keys.MULTIPLE_MYELOMA.CSMR)  # EMR_s = ACMR - CSMR
+                builder.data.load(data_keys.POPULATION.ACMR)  # EMR_s = ACMR - CSMR
                 - builder.data.load(data_keys.MULTIPLE_MYELOMA.GBD_CSMR)),
         }
     )

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
@@ -186,9 +186,9 @@ class MortalityObserver(MortalityObserver_):
         pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
 
         measure_getters = (
-            (get_deaths, (self.causes,)),
+            (get_deaths, (self.causes + [models.SUSCEPTIBLE_STATE_NAME],)),
             (get_person_time, ()),
-            (get_years_of_life_lost, (self.life_expectancy, self.causes)),
+            (get_years_of_life_lost, (self.life_expectancy, self.causes + [models.SUSCEPTIBLE_STATE_NAME])),
         )
 
         for labels, pop_in_group in self.stratifier.group(pop):

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
@@ -38,8 +38,8 @@ def make_treatment_coverage(year, scenario):
 
     coverage_data = coverages[(year, scenario)]
     coverage = pd.DataFrame({
-        models.TREATMENTS.isatuxamib: coverage_data[0],
-        models.TREATMENTS.daratumamab: coverage_data[1],
+        models.TREATMENTS.isatuximab: coverage_data[0],
+        models.TREATMENTS.daratumumab: coverage_data[1],
     }, index=TREATMENT_LINES)
     coverage[models.TREATMENTS.residual] = 1 - coverage.sum(axis=1)
     return coverage
@@ -52,15 +52,15 @@ def make_progression_hazard_ratio(draw: int):
     hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
-    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
-    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
     hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = PROGRESSION_HAZARD_RATE.FIRST_LINE_RESIDUAL.get_random_variable(draw)
 
     for line in TREATMENT_LINES.tolist()[1:]:
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
         hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = PROGRESSION_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
         hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = PROGRESSION_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
 
@@ -78,15 +78,15 @@ def make_mortality_hazard_ratio(draw: int):
     hazard_ratio.loc[(models.SUSCEPTIBLE_STATE_NAME, models.TREATMENTS.not_treated, False)] = 1.0
 
     line = models.MULTIPLE_MYELOMA_1_STATE_NAME
-    hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
-    hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_ISA.get_random_variable(draw)
+    hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_DARA.get_random_variable(draw)
     hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = MORTALITY_HAZARD_RATE.FIRST_LINE_RESIDUAL.get_random_variable(draw)
 
     for line in TREATMENT_LINES.tolist()[1:]:
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.isatuxamib, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
-        hazard_ratio.loc[(line, models.TREATMENTS.daratumamab, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.isatuximab, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_ISA_RETREAT.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA.get_random_variable(draw)
+        hazard_ratio.loc[(line, models.TREATMENTS.daratumumab, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_DARA_RETREAT.get_random_variable(draw)
         hazard_ratio.loc[(line, models.TREATMENTS.residual, True)] = MORTALITY_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
         hazard_ratio.loc[(line, models.TREATMENTS.residual, False)] = MORTALITY_HAZARD_RATE.LATER_LINE_RESIDUAL.get_random_variable(draw)
 
@@ -119,7 +119,7 @@ class MultipleMyelomaTreatmentCoverage:
 
         # What treatment are they currently on.
         self.treatment_column = 'multiple_myeloma_treatment'
-        # Did they previously recieve isatuxamib or daratumumab
+        # Did they previously recieve isatuximab or daratumumab
         self.retreatment_eligible_column = 'retreatment_eligible'
         self.retreated_column = 'retreated'
         columns_created = [
@@ -166,7 +166,7 @@ class MultipleMyelomaTreatmentCoverage:
         )
         pop_update.loc[with_mm.index, self.treatment_column] = treatment
         dara_or_isa = pop_update[self.treatment_column].isin(
-            [models.TREATMENTS.daratumamab, models.TREATMENTS.isatuxamib]
+            [models.TREATMENTS.daratumumab, models.TREATMENTS.isatuximab]
         )
         pop_update.loc[dara_or_isa, self.retreatment_eligible_column] = 'true'
         self.population_view.update(pop_update)
@@ -183,12 +183,12 @@ class MultipleMyelomaTreatmentCoverage:
         lines = TREATMENT_LINES.tolist()
         for current_line, previous_line in zip(lines, [None] + lines[:-1]):
             # First, unpack probabilities for the current and previous line.
-            p_isa_c = coverage.at[current_line, models.TREATMENTS.isatuxamib]
-            p_dara_c = coverage.at[current_line, models.TREATMENTS.daratumamab]
+            p_isa_c = coverage.at[current_line, models.TREATMENTS.isatuximab]
+            p_dara_c = coverage.at[current_line, models.TREATMENTS.daratumumab]
             p_resid_c = coverage.at[current_line, models.TREATMENTS.residual]
             if previous_line:
-                p_isa_p = coverage.at[previous_line, models.TREATMENTS.isatuxamib]
-                p_dara_p = coverage.at[previous_line, models.TREATMENTS.daratumamab]
+                p_isa_p = coverage.at[previous_line, models.TREATMENTS.isatuximab]
+                p_dara_p = coverage.at[previous_line, models.TREATMENTS.daratumumab]
                 p_resid_p = coverage.at[previous_line, models.TREATMENTS.residual]
             else:
                 p_isa_p, p_dara_p, p_resid_p = 0., 0., 1.
@@ -198,7 +198,7 @@ class MultipleMyelomaTreatmentCoverage:
 
             # First group, getting their 2nd+ round of isa/dara
             retreat = new_treatment_line & retreatment_eligible & retreat_mask
-            retreat_choices = [models.TREATMENTS.isatuxamib, models.TREATMENTS.daratumamab]
+            retreat_choices = [models.TREATMENTS.isatuximab, models.TREATMENTS.daratumumab]
             retreat_probs = [p_isa_c / (p_isa_c + p_dara_c), p_dara_c / (p_isa_c + p_dara_c)]
 
             pop.loc[retreat, self.treatment_column] = self.randomness.choice(
@@ -221,7 +221,7 @@ class MultipleMyelomaTreatmentCoverage:
 
             # Third group, getting their first dose of isa/dara and determining if they can be retreated.
             unknown_retreat = new_treatment_line & retreatment_unknown
-            unknown_choices = [models.TREATMENTS.isatuxamib, models.TREATMENTS.daratumamab, models.TREATMENTS.residual]
+            unknown_choices = [models.TREATMENTS.isatuximab, models.TREATMENTS.daratumumab, models.TREATMENTS.residual]
             # TODO: add a link to the docs when they're live for this algorithm.
             old_to_new_scale = (p_isa_p + p_dara_p) / (p_isa_c + p_dara_c)
             final_scale = (1 - PROBABILITY_RETREAT * old_to_new_scale) / p_resid_p
@@ -238,7 +238,7 @@ class MultipleMyelomaTreatmentCoverage:
                 p=unknown_treatment_probs,
             )
             isa_or_dara = pop[self.treatment_column].isin([
-                models.TREATMENTS.isatuxamib, models.TREATMENTS.daratumamab
+                models.TREATMENTS.isatuximab, models.TREATMENTS.daratumumab
             ])
             pop.loc[unknown_retreat & isa_or_dara, self.retreatment_eligible_column] = 'true'
             # These are no-ops.  Here for clarity.
@@ -248,7 +248,7 @@ class MultipleMyelomaTreatmentCoverage:
         self.population_view.update(pop)
 
     def get_current_coverage(self, time: pd.Timestamp) -> pd.DataFrame:
-        """Get a df with columns: [TREATMENTS.isatuxamib, TREATMENTS.daratumamab, TREATMENTS.residual]
+        """Get a df with columns: [TREATMENTS.isatuximab, TREATMENTS.daratumumab, TREATMENTS.residual]
         indexed by multiple myeloma state."""
         if time.year < 2021:
             return self.coverage_2021
@@ -256,7 +256,7 @@ class MultipleMyelomaTreatmentCoverage:
             return self.coverage_2025
         t = (time - pd.Timestamp('2021-01-01')) / (pd.Timestamp('2026-01-01') - pd.Timestamp('2021-01-01'))
 
-        treatments = [models.TREATMENTS.isatuxamib, models.TREATMENTS.daratumamab]
+        treatments = [models.TREATMENTS.isatuximab, models.TREATMENTS.daratumumab]
         slope = self.coverage_2025[treatments] - self.coverage_2021[treatments]
         coverage = self.coverage_2021[treatments] + slope * t
         coverage[models.TREATMENTS.residual] = 1 - coverage.sum(axis=1)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_keys.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_keys.py
@@ -63,6 +63,7 @@ class __MultipleMyeloma(NamedTuple):
     LINE_5_EMR: TargetString = TargetString('cause.multiple_myeloma_5.excess_mortality_rate')
 
     GBD_CSMR: TargetString = TargetString('cause.multiple_myeloma_gbd.cause_specific_mortality_rate')
+    SUSCEPTIBLE_EMR: TargetString = TargetString('cause.susceptible_to_multiple_myeloma.excess_mortality_rate')
 
     @property
     def name(self):

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_keys.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_keys.py
@@ -62,6 +62,8 @@ class __MultipleMyeloma(NamedTuple):
     LINE_5_DISABILITY_WEIGHT: TargetString = TargetString('cause.multiple_myeloma_5.disability_weight')
     LINE_5_EMR: TargetString = TargetString('cause.multiple_myeloma_5.excess_mortality_rate')
 
+    GBD_CSMR: TargetString = TargetString('cause.multiple_myeloma_gbd.cause_specific_mortality_rate')
+
     @property
     def name(self):
         return 'multiple_myeloma'

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/models.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/models.py
@@ -55,8 +55,8 @@ TRANSITIONS = tuple(state for model in STATE_MACHINE_MAP.values() for state in m
 
 class __Treatments(NamedTuple):
     not_treated: str
-    isatuxamib: str
-    daratumamab: str
+    isatuximab: str
+    daratumumab: str
     residual: str
 
 

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -52,7 +52,8 @@ NON_COUNT_TEMPLATES = [
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-YEARS = tuple(range(2011, 2026))
+#XXX
+YEARS = tuple(range(2021, 2026))
 AGE_GROUPS = (
     '15_to_19',
     '20_to_24',
@@ -75,6 +76,7 @@ AGE_GROUPS = (
 # TODO - add causes of death
 CAUSES_OF_DEATH = (
     'other_causes',
+    models.SUSCEPTIBLE_STATE_NAME,
     models.MULTIPLE_MYELOMA_1_STATE_NAME,
     models.MULTIPLE_MYELOMA_2_STATE_NAME,
     models.MULTIPLE_MYELOMA_3_STATE_NAME,

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -52,7 +52,7 @@ NON_COUNT_TEMPLATES = [
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-YEARS = tuple(range(2021, 2026))
+YEARS = tuple(range(2011, 2026))
 AGE_GROUPS = (
     '15_to_19',
     '20_to_24',

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -52,7 +52,6 @@ NON_COUNT_TEMPLATES = [
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-#XXX
 YEARS = tuple(range(2011, 2026))
 AGE_GROUPS = (
     '15_to_19',

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -53,7 +53,7 @@ NON_COUNT_TEMPLATES = [
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
 #XXX
-YEARS = tuple(range(2021, 2026))
+YEARS = tuple(range(2011, 2026))
 AGE_GROUPS = (
     '15_to_19',
     '20_to_24',

--- a/src/vivarium_csu_sanofi_multiple_myeloma/data/loader.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/data/loader.py
@@ -72,6 +72,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.MULTIPLE_MYELOMA.LINE_5_EMR: load_rrmm_emr,
 
         data_keys.MULTIPLE_MYELOMA.GBD_CSMR: load_gbd_csmr,
+        data_keys.MULTIPLE_MYELOMA.SUSCEPTIBLE_EMR: load_susceptible_emr,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -144,7 +145,7 @@ def load_rrmm_prevalence(state: str) -> pd.DataFrame:
         models.MULTIPLE_MYELOMA_5_STATE_NAME: 0.,
     }
 
-    def _load_rrmm_prevalence(key, location):
+    def _load_rrmm_prevalence(key, location) -> pd.DataFrame:
         return load_standard_data('cause.multiple_myeloma.prevalence', location) * state_multipliers[state]
     return _load_rrmm_prevalence
 
@@ -155,6 +156,13 @@ def load_rrmm_disability_weight(key: str, location):
 
 def load_rrmm_emr(key: str, location):
     return load_standard_data('cause.multiple_myeloma.excess_mortality_rate', location)
+
+
+def load_susceptible_emr(key: str, location):
+    INDEX_COLUMNS = ['sex', 'age_start', 'age_end', 'year_start', 'year_end']
+    return (load_acmr(key, location).reset_index().set_index(INDEX_COLUMNS)
+            - load_gbd_csmr(key, location).reset_index().set_index(INDEX_COLUMNS))
+
 
 def get_entity(key: str):
     # Map of entity types to their gbd mappings.

--- a/src/vivarium_csu_sanofi_multiple_myeloma/data/loader.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/data/loader.py
@@ -50,7 +50,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.MULTIPLE_MYELOMA.PREVALENCE: load_rrmm_prevalence(models.MULTIPLE_MYELOMA_1_STATE_NAME),
         data_keys.MULTIPLE_MYELOMA.INCIDENCE_RATE: load_standard_data,
         data_keys.MULTIPLE_MYELOMA.DISABILITY_WEIGHT: load_rrmm_disability_weight,
-        data_keys.MULTIPLE_MYELOMA.CSMR: load_standard_data,
+        data_keys.MULTIPLE_MYELOMA.CSMR: load_acmr,
         data_keys.MULTIPLE_MYELOMA.RESTRICTIONS: load_metadata,
 
         data_keys.MULTIPLE_MYELOMA.LINE_1_PREVALENCE: load_rrmm_prevalence(models.MULTIPLE_MYELOMA_1_STATE_NAME),
@@ -70,6 +70,8 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.MULTIPLE_MYELOMA.LINE_3_EMR: load_rrmm_emr,
         data_keys.MULTIPLE_MYELOMA.LINE_4_EMR: load_rrmm_emr,
         data_keys.MULTIPLE_MYELOMA.LINE_5_EMR: load_rrmm_emr,
+
+        data_keys.MULTIPLE_MYELOMA.GBD_CSMR: load_gbd_csmr,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -125,7 +127,15 @@ def _load_em_from_meid(location, meid, measure):
 
 
 # TODO - add project-specific data functions here
-def load_rrmm_prevalence(state: str):
+def load_acmr(key: str, location) -> pd.DataFrame:
+    return load_standard_data('cause.all_causes.cause_specific_mortality_rate', location)
+
+
+def load_gbd_csmr(key: str, location) -> pd.DataFrame:
+    return load_standard_data('cause.multiple_myeloma.cause_specific_mortality_rate', location)
+
+
+def load_rrmm_prevalence(state: str) -> pd.DataFrame:
     state_multipliers = {
         models.MULTIPLE_MYELOMA_1_STATE_NAME: 1.,
         models.MULTIPLE_MYELOMA_2_STATE_NAME: 0.,

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
@@ -30,7 +30,7 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2021
+            year: 2011
             month: 1
             day: 1
         end:


### PR DESCRIPTION
This change updates the simulation to made a change in the model detailed in:

https://github.com/ihmeuw/vivarium_research/pull/520/files

Specifically, it replaces the CSMR for multiple myeloma with ACMR and replaces the EMR (0) for the susceptible state with ACMR - CSMR_c486.

Also, this change includes a burn-in period of 10 years (2011-2021) and corrects misspellings of isatuximab and datatumumab.

Tested with a remade artifact, full parallel run and results processing. Output looked as expected using the survival analysis notebook and perusing the csvs in count space. Note: other_cause deaths are counted as deaths by the susceptible state due to a workaround for mortality data (susceptible having an EMR).

