### PR TITLE
Fix typo in pfs upper bound, add assert to watch for similar issues

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
@@ -8,7 +8,7 @@ PFS_HR = {
     (models.MULTIPLE_MYELOMA_1_STATE_NAME, models.TREATMENTS.isatuximab, False): (0.932, 0.647, 1.365),
     (models.MULTIPLE_MYELOMA_1_STATE_NAME, models.TREATMENTS.daratumumab, False): (0.932, 0.647, 1.365),
     (models.MULTIPLE_MYELOMA_1_STATE_NAME, models.TREATMENTS.residual, False): (1.002, 0.989, 1.018),
-    (models.MULTIPLE_MYELOMA_2_STATE_NAME, models.TREATMENTS.isatuximab, False): (1.283, 0.878, 1.178),
+    (models.MULTIPLE_MYELOMA_2_STATE_NAME, models.TREATMENTS.isatuximab, False): (1.283, 0.878, 1.718),
     (models.MULTIPLE_MYELOMA_2_STATE_NAME, models.TREATMENTS.isatuximab, True): (1.632, 0.905, 2.733),
     (models.MULTIPLE_MYELOMA_2_STATE_NAME, models.TREATMENTS.daratumumab, False): (1.146, 1.000, 1.318),
     (models.MULTIPLE_MYELOMA_2_STATE_NAME, models.TREATMENTS.daratumumab, True): (1.333, 0.995, 1.702),

--- a/src/vivarium_csu_sanofi_multiple_myeloma/utilities.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/utilities.py
@@ -101,6 +101,7 @@ class LogNormalHazardRate:
         q_975_stdnorm = norm().ppf(0.975)
         mu = np.log(self.hr)
         sigma = (np.log(self.hr_upper) - mu) / q_975_stdnorm
+        assert sigma > 0, "look for typos"
         self.hr_distribution = lognorm(s=sigma, scale=self.hr)
 
     def get_random_variable(self, percentile: float) -> float:


### PR DESCRIPTION
The upper bound in this line should read 1.718 rather than 1.178 due to a transposing error. Added an assert to watch for the issue that indicated this bug.