### PR TITLE
Feature/mic 2566 race assumptions

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/risk_effect.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/risk_effect.py
@@ -47,7 +47,7 @@ class MultipleMyelomaRiskEffects:
         self.required_columns = required_columns
         created_columns = list(RISKS)
 
-        race_impact_scenario = builder.configuration.mm_scenarios.hazard_rate_source
+        race_impact_scenario = builder.configuration.mm_scenarios.race_impact_scenario
         if race_impact_scenario == RACE_IMPACT_SCENARIO.commpass_registry:
             os = RISK_OS_HR_2A
             pfs = RISK_PFS_HR_2A

--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/treatment.py
@@ -132,7 +132,8 @@ class MultipleMyelomaTreatmentCoverage:
         # Did they previously receive isatuximab or daratumumab
         self.ever_isa_or_dara_column = 'ever_isa_or_dara'
         self.retreated_column = 'retreated'
-        self.registry_evaluation_status = 'registry_evaluation_status'  # 4 potential values: unevaluated, eligible, enrolled
+        # registry_evaluation_status has 3 potential values: unevaluated, eligible, enrolled
+        self.registry_evaluation_status = 'registry_evaluation_status'
         self.registry_evaluation_date = 'registry_evaluation_date'
         self.ever_isa = 'ever_isa'
         self.registry_start_date = pd.Timestamp('2021-01-01')
@@ -323,7 +324,7 @@ class MultipleMyelomaTreatmentEffect:
             os = RCT_OS_HR
             pfs = RCT_PFS_HR
         else:
-            raise ValueError(f"Unrecognized configuration.hazard_rate_source {str(hazard_rate_source)}")
+            raise ValueError(f"Unknown configuration.mm_scenarios.hazard_rate_source {str(hazard_rate_source)}")
         progression_hazard_ratio, mortality_hazard_ratio = make_hazard_ratios(draw, pfs, os)
         self.progression_hazard_ratio = builder.lookup.build_table(
             progression_hazard_ratio,

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/data_values.py
@@ -157,28 +157,57 @@ RENAL_RISK_EXPOSURE = {
     RISK_EXPOSURE_LEVELS.renal_unimpaired: (1 - RENAL_RISK_EXPOSURE)
 }
 
-RISK_PFS_HR = {
-    RISK_EXPOSURE_LEVELS.Male: (1.117379506, 1.023631793, 1.206248002),
-    RISK_EXPOSURE_LEVELS.Female: (0.862760188, 0.758855373, 0.97236977),
-    RISK_EXPOSURE_LEVELS.over_65: (1.168929731, 1.109344393, 1.225450674),
-    RISK_EXPOSURE_LEVELS.under_65: (0.690375253, 0.58678021, 0.799586905),
-    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.311878770, 1.056678749, 1.584507832),
-    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (0.960405579, 0.898572409, 1.020472796),
-    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (1.311878770, 1.056678749, 1.584507832),
-    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.745715288, 0.624228519, 0.886872848),
-    RISK_EXPOSURE_LEVELS.renal_impaired: (1.366074674, 1.140038711, 1.60581245),
-    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.967734441, 0.946604126, 0.987657089)
+# Hazard ratios from the CoMMpass registry (2a)
+RISK_PFS_HR_2A = {
+    RISK_EXPOSURE_LEVELS.Male: (1.12, 1.02, 1.21),
+    RISK_EXPOSURE_LEVELS.Female: (0.86, 0.76, 0.97),
+    RISK_EXPOSURE_LEVELS.over_65: (1.17, 1.11, 1.23),
+    RISK_EXPOSURE_LEVELS.under_65: (0.69, 0.59, 0.8),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.31, 1.06, 1.59),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (1.31, 1.06, 1.59),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (1.31, 1.06, 1.59),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.75, 0.62, 0.89),
+    RISK_EXPOSURE_LEVELS.renal_impaired: (1.37, 1.14, 1.61),
+    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.97, 0.95, 0.99)
 }
 
-RISK_OS_HR = {
-    RISK_EXPOSURE_LEVELS.Male: (1.255109255, 1.112976053, 1.375112298),
-    RISK_EXPOSURE_LEVELS.Female: (0.701726923, 0.561419677, 0.867908693),
-    RISK_EXPOSURE_LEVELS.over_65: (1.236326008, 1.157185865, 1.302944895),
-    RISK_EXPOSURE_LEVELS.under_65: (0.566847231, 0.44474406, 0.711900129),
-    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.519586719, 1.147138585, 1.906550411),
-    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (0.940421232, 0.852859054, 1.026932501),
-    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (1.519586719, 1.147138585, 1.906550411),
-    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.532865764, 0.345350636, 0.786647960),
-    RISK_EXPOSURE_LEVELS.renal_impaired: (1.788742852, 1.35961846, 2.299354949),
-    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.930480771, 0.885475788, 0.968303487)
+RISK_OS_HR_2A = {
+    RISK_EXPOSURE_LEVELS.Male: (1.26, 1.11, 1.38),
+    RISK_EXPOSURE_LEVELS.Female: (0.7, 0.56, 0.87),
+    RISK_EXPOSURE_LEVELS.over_65: (1.24, 1.16, 1.3),
+    RISK_EXPOSURE_LEVELS.under_65: (0.57, 0.44, 0.71),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.52, 1.15, 1.91),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (0.94, 0.85, 1.03),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (1.52, 1.15, 1.91),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.53, 0.35, 0.79),
+    RISK_EXPOSURE_LEVELS.renal_impaired: (1.79, 1.36, 2.3),
+    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.93, 0.89, 0.97)
+}
+
+# Assumption of no impact of race on multiple myeloma survival outcomes independent of age (2b)
+# i.e., race_impact_scenario == no_impact
+RISK_PFS_HR_2B = {
+    RISK_EXPOSURE_LEVELS.Male: (1.12, 1.02, 1.21),
+    RISK_EXPOSURE_LEVELS.Female: (0.86, 0.76, 0.97),
+    RISK_EXPOSURE_LEVELS.over_65: (1.17, 1.11, 1.23),
+    RISK_EXPOSURE_LEVELS.under_65: (0.69, 0.59, 0.8),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.06, 1.03, 1.08),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (1.06, 1.03, 1.08),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (0.63, 0.49, 0.79),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.63, 0.49, 0.79),
+    RISK_EXPOSURE_LEVELS.renal_impaired: (1.37, 1.14, 1.61),
+    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.97, 0.95, 0.99)
+}
+
+RISK_OS_HR_2B = {
+    RISK_EXPOSURE_LEVELS.Male: (1.26, 1.11, 1.38),
+    RISK_EXPOSURE_LEVELS.Female: (0.7, 0.56, 0.87),
+    RISK_EXPOSURE_LEVELS.over_65: (1.24, 1.16, 1.3),
+    RISK_EXPOSURE_LEVELS.under_65: (0.57, 0.44, 0.71),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_black: (1.05, 1.02, 1.07),
+    RISK_EXPOSURE_LEVELS.high_cytogenetic_risk_and_non_black: (1.05, 1.02, 1.07),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_black: (0.66, 0.52, 0.84),
+    RISK_EXPOSURE_LEVELS.low_cytogenetic_risk_and_non_black: (0.66, 0.52, 0.84),
+    RISK_EXPOSURE_LEVELS.renal_impaired: (1.79, 1.36, 2.3),
+    RISK_EXPOSURE_LEVELS.renal_unimpaired: (0.93, 0.89, 0.97)
 }

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/metadata.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/metadata.py
@@ -32,3 +32,11 @@ class __HazardRateSources(NamedTuple):
 
 
 HAZARD_RATE_SOURCES = __HazardRateSources(*__HazardRateSources._fields)
+
+
+class __RaceImpactScenario(NamedTuple):
+    commpass_registry: str
+    no_impact: str
+
+
+RACE_IMPACT_SCENARIO = __RaceImpactScenario(*__RaceImpactScenario._fields)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -15,6 +15,7 @@ INPUT_DRAW_COLUMN = 'input_draw'
 RANDOM_SEED_COLUMN = 'random_seed'
 OUTPUT_SCENARIO_COLUMN = 'mm_scenarios.mm_treatment_scenario'
 HAZARD_RATE_SOURCE_COLUMN = 'mm_scenarios.hazard_rate_source'
+RACE_IMPACT_SCENARIO_COLUMN = 'mm_scenarios.race_impact_scenario'
 
 STANDARD_COLUMNS = {
     'total_population': TOTAL_POPULATION_COLUMN,

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/branches/scenarios.yaml
@@ -5,3 +5,4 @@ branches:
   - mm_scenarios:
       mm_treatment_scenario: ['baseline', 'alternative']
       hazard_rate_source: ['population', 'clinical_trial']
+      race_impact_scenario: ['commpass_registry', 'no_impact']

--- a/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/model_specifications/united_states_of_america.yaml
@@ -65,3 +65,4 @@ configuration:
     mm_scenarios:
         mm_treatment_scenario: 'baseline'
         hazard_rate_source: 'population'
+        race_impact_scenario: 'commpass_registry'

--- a/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
@@ -10,10 +10,12 @@ from vivarium_csu_sanofi_multiple_myeloma.constants.data_values import RISKS
 
 SCENARIO_COLUMN = 'scenario'
 HAZARD_RATE_SOURCE_COLUMN = 'hazard_rate_source'
+RACE_IMPACT_SCENARIO_COLUMN = 'race_impact_scenario'
 GROUPBY_COLUMNS = [
     results.INPUT_DRAW_COLUMN,
     SCENARIO_COLUMN,
-    HAZARD_RATE_SOURCE_COLUMN
+    HAZARD_RATE_SOURCE_COLUMN,
+    RACE_IMPACT_SCENARIO_COLUMN
 ]
 OUTPUT_COLUMN_SORT_ORDER = [
     'age_group',
@@ -68,6 +70,7 @@ def read_data(path: Path, single_run: bool) -> (pd.DataFrame, List[str]):
             .reset_index(drop=True)
             .rename(columns={results.OUTPUT_SCENARIO_COLUMN: SCENARIO_COLUMN})
             .rename(columns={results.HAZARD_RATE_SOURCE_COLUMN: HAZARD_RATE_SOURCE_COLUMN})
+            .rename(columns={results.RACE_IMPACT_SCENARIO_COLUMN: RACE_IMPACT_SCENARIO_COLUMN})
             )
     if single_run:
         data[results.INPUT_DRAW_COLUMN] = 0
@@ -76,7 +79,8 @@ def read_data(path: Path, single_run: bool) -> (pd.DataFrame, List[str]):
         keyspace = {results.INPUT_DRAW_COLUMN: [0],
                     results.RANDOM_SEED_COLUMN: [0],
                     results.OUTPUT_SCENARIO_COLUMN: ['baseline'],
-                    results.HAZARD_RATE_SOURCE_COLUMN: ['population']}
+                    results.HAZARD_RATE_SOURCE_COLUMN: ['population'],
+                    results.RACE_IMPACT_SCENARIO_COLUMN: ['commpass_registry']}
     else:
         data[results.INPUT_DRAW_COLUMN] = data[results.INPUT_DRAW_COLUMN].astype(int)
         data[results.RANDOM_SEED_COLUMN] = data[results.RANDOM_SEED_COLUMN].astype(int)


### PR DESCRIPTION
- Adds a scenario of race impact scenario. Existing "default" is 'commpass_registry' and the new alternative added is 'no_impact', correlating to 2a and 2b in the model document.
- Adds new 'race_impact_scenario' column handling in the results
- Updates the high-precision values for PFS and OS hazard ratios to match the lower-precision values in the model document. Previous values were received from research in CSV format.