### PR TITLE
Add stratification by risks and renal status

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/results_processing/process_results.py
@@ -156,22 +156,6 @@ def split_processing_column(data, stratified_by_treatment=False, stratified_by_r
     return data.drop(columns='process')
 
 
-def new_split_processing_column(data, stratified_by_treatment=False, stratified_by_risks=False):
-    out = {'measure': [], 'year': [], 'sex': [], 'age': []}
-    if stratified_by_treatment:
-        out['treatment'] = []
-        out['retreated'] = []
-    if stratified_by_risks:
-        out['renal_function_at_diagnosis'] = []
-        out['race_and_cytogenetic_risk_at_diagnosis'] = []
-    out['value'] = []
-
-    for k, v in data.iterrows():
-        pass
-
-    # return data.drop(columns='process')
-
-
 def get_population_data(data):
     total_pop = pivot_data(data[[results.TOTAL_POPULATION_COLUMN]
                                 + results.RESULT_COLUMNS('population')


### PR DESCRIPTION
This change includes everything in results processing for race/cytogenetic risk and renal function stratifications to MM count space outcomes of transition, death, and state person time. Because of all these stratifications, the results are large (largest CSV file is about 20 GB), and `make_results` took up to 7 hours. Further work will make these operations less inefficient.

It also changes the column names to be consistent. In places, some column names were in all caps. These have all been changed to lower case.

Tested with a full parallel run and `make_results`.