### PR TITLE
Resolve issue resulting in 0 accounting in susceptible state

### DIFF
--- a/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/components/observers.py
@@ -14,7 +14,7 @@ from vivarium_public_health.metrics.utilities import (get_age_bins, get_deaths, 
                                                       get_years_of_life_lost, TransitionString)
 
 from vivarium_csu_sanofi_multiple_myeloma.constants import data_values, models, results
-from vivarium_csu_sanofi_multiple_myeloma.constants.data_values import RISKS, RISK_LEVEL_MAP
+from vivarium_csu_sanofi_multiple_myeloma.constants.data_values import RISKS, RISK_LEVEL_MAP, UNDIAGNOSED
 
 
 class ResultsStratifier:
@@ -74,11 +74,11 @@ class ResultsStratifier:
                 race_and_cytogenetic_risk_at_diagnosis: get_race_and_cytogenetic_risk_at_diagnosis_function(
                     race_and_cytogenetic_risk_at_diagnosis)
                 for race_and_cytogenetic_risk_at_diagnosis
-                in RISK_LEVEL_MAP[RISKS.race_and_cytogenetic_risk_at_diagnosis]
+                in RISK_LEVEL_MAP[RISKS.race_and_cytogenetic_risk_at_diagnosis] + [UNDIAGNOSED]
             }
             self.stratification_levels['renal_function_at_diagnosis'] = {
                 renal_function_at_diagnosis: get_renal_function_at_diagnosis(renal_function_at_diagnosis)
-                for renal_function_at_diagnosis in RISK_LEVEL_MAP[RISKS.renal_function_at_diagnosis]
+                for renal_function_at_diagnosis in RISK_LEVEL_MAP[RISKS.renal_function_at_diagnosis] + [UNDIAGNOSED]
             }
 
         self.population_view = builder.population.get_view(columns_required)

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -115,8 +115,8 @@ TEMPLATE_FIELD_MAP = {
     'RIGHT_PERIOD': ALL_PERIODS[1:],
     'SEX_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.sex_at_diagnosis],
     'AGE_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.age_at_diagnosis],
-    'RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.race_and_cytogenetic_risk_at_diagnosis],
-    'RENAL_FUNCTION_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.renal_function_at_diagnosis],
+    'RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.race_and_cytogenetic_risk_at_diagnosis] + [data_values.UNDIAGNOSED],
+    'RENAL_FUNCTION_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.renal_function_at_diagnosis] + [data_values.UNDIAGNOSED],
     'REGISTRY_STATUS': ['newly_eligible', 'newly_enrolled', 'enrolled']
 }
 

--- a/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
+++ b/src/vivarium_csu_sanofi_multiple_myeloma/constants/results.py
@@ -1,6 +1,7 @@
 import itertools
 
-from vivarium_csu_sanofi_multiple_myeloma.constants import models, data_values
+from vivarium_csu_sanofi_multiple_myeloma.constants import models
+from vivarium_csu_sanofi_multiple_myeloma.constants.data_values import RISKS, RISK_LEVEL_MAP, UNDIAGNOSED
 
 #################################
 # Results columns and variables #
@@ -26,15 +27,15 @@ STANDARD_COLUMNS = {
 THROWAWAY_COLUMNS = [f'{state}_event_count' for state in models.STATES]
 
 TOTAL_POPULATION_COLUMN_TEMPLATE = 'total_population_{POP_STATE}'
-PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
-DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
-YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
+PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS_EXT}'
+DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS_EXT}'
+YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS_EXT}'
 YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}'
-STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
-TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
+STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS_EXT}'
+TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_treatment_state_{TREATMENT}_retreated_{BOOL}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS_EXT}'
 TREATMENT_COUNT_COLUMN_TEMPLATE = 'line_{TREATMENT_LINE}_treatment_{TREATMENT}_year_{YEAR}'
-SURVIVAL_ALIVE_TEMPLATE = 'alive_at_period_{LEFT_PERIOD}_line_{TREATMENT_LINE}' + '_' + '_'.join([f'{s}_{{{s.upper()}}}' for s in data_values.RISKS])
-SURVIVAL_OTHER_TEMPLATE = '{SURVIVAL_METRIC}_period_{RIGHT_PERIOD}_line_{TREATMENT_LINE}' + '_' + '_'.join([f'{s}_{{{s.upper()}}}' for s in data_values.RISKS])
+SURVIVAL_ALIVE_TEMPLATE = 'alive_at_period_{LEFT_PERIOD}_line_{TREATMENT_LINE}' + '_' + '_'.join([f'{s}_{{{s.upper()}}}' for s in RISKS])
+SURVIVAL_OTHER_TEMPLATE = '{SURVIVAL_METRIC}_period_{RIGHT_PERIOD}_line_{TREATMENT_LINE}' + '_' + '_'.join([f'{s}_{{{s.upper()}}}' for s in RISKS])
 REGISTRY_TEMPLATE = 'registry_status_{REGISTRY_STATUS}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_race_and_cytogenetic_risk_at_diagnosis_{RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS}_renal_function_at_diagnosis_{RENAL_FUNCTION_AT_DIAGNOSIS}'
 
 COLUMN_TEMPLATES = {
@@ -113,10 +114,14 @@ TEMPLATE_FIELD_MAP = {
     # CAUTION: This needs to change with the time step size.
     'LEFT_PERIOD': ALL_PERIODS[:-1],
     'RIGHT_PERIOD': ALL_PERIODS[1:],
-    'SEX_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.sex_at_diagnosis],
-    'AGE_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.age_at_diagnosis],
-    'RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.race_and_cytogenetic_risk_at_diagnosis] + [data_values.UNDIAGNOSED],
-    'RENAL_FUNCTION_AT_DIAGNOSIS': data_values.RISK_LEVEL_MAP[data_values.RISKS.renal_function_at_diagnosis] + [data_values.UNDIAGNOSED],
+    'SEX_AT_DIAGNOSIS': RISK_LEVEL_MAP[RISKS.sex_at_diagnosis],
+    'AGE_AT_DIAGNOSIS': RISK_LEVEL_MAP[RISKS.age_at_diagnosis],
+    'RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS': RISK_LEVEL_MAP[
+        RISKS.race_and_cytogenetic_risk_at_diagnosis],
+    'RENAL_FUNCTION_AT_DIAGNOSIS': RISK_LEVEL_MAP[RISKS.renal_function_at_diagnosis],
+    'RACE_AND_CYTOGENETIC_RISK_AT_DIAGNOSIS_EXT': RISK_LEVEL_MAP[
+                                                      RISKS.race_and_cytogenetic_risk_at_diagnosis] + [UNDIAGNOSED],
+    'RENAL_FUNCTION_AT_DIAGNOSIS_EXT': RISK_LEVEL_MAP[RISKS.renal_function_at_diagnosis] + [UNDIAGNOSED],
     'REGISTRY_STATUS': ['newly_eligible', 'newly_enrolled', 'enrolled']
 }
 


### PR DESCRIPTION
There was a bug in the results stratifier where records whose values that are only set at diagnosis (i.e., `undiagnosed`) were not counted in results. This meant that everyone who was in the susceptible state (by definition undiagnosed and not with-condition) were left out of stratification. This issue did not affect survival or registry results as those data already are limited to those outside of the susceptible state. 

Tested with a single simulate run and results processing. Full parallel run is underway.